### PR TITLE
trigger docs/linter workflows on PRs only

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,6 @@
 name: docs
 
-on: [push]
+on: pull_request
 
 jobs:
   build:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 name: lint
 
-on: [push]
+on: pull_request
 
 jobs:
   build:
@@ -9,6 +9,8 @@ jobs:
     steps:
       - name: Checkout master
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
 
       - name: Set up python
         uses: actions/setup-python@v1
@@ -32,3 +34,4 @@ jobs:
         with:
           commit_message: "style: reformat with black"
           commit_author: "Github Actions <actions@github.com>"
+          branch: ${{ github.head_ref }}


### PR DESCRIPTION
To reduce build times, let's only check that our docs build and our code style is `black` on PRs. 