### PR TITLE
Refactor __init__.py via app factory paradigm

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,35 +1,37 @@
+"""
+Marks dir as package and returns a configured instance of the Flask app.
+"""
 import os
 
 from flask import Flask
 from flask_login import LoginManager
 from flask_sqlalchemy import SQLAlchemy
 
-
-# Initialization
-# Create an application instance (an object of class Flask) which handles all requests.
-application = Flask(__name__)
-application.secret_key = os.urandom(33)  # For CSRF token
-application.config.from_object("app.config.Config")
-
-# Create DB
-db = SQLAlchemy(application)
-db.create_all()
-db.session.commit()
-
-# login_manager needs to be initiated before running the app
+db = SQLAlchemy()
 login_manager = LoginManager()
-login_manager.init_app(application)
 
-from app.api import mobile
-from app.views import auth
-from app.views import dashboard
-from app.views import home
-from app.views import patients
-from app.views import prescriptions
 
-application.register_blueprint(mobile.bp)
-application.register_blueprint(auth.bp)
-application.register_blueprint(dashboard.bp)
-application.register_blueprint(home.bp)
-application.register_blueprint(patients.bp)
-application.register_blueprint(prescriptions.bp)
+def create_app():
+    """Create and configure an instance of the Flask app."""
+    app = Flask(__name__)
+    app.secret_key = os.urandom(33)  # For CSRF token
+    app.config.from_object("app.config.Config")
+
+    login_manager.init_app(app)
+    db.init_app(app)
+
+    from app.api import mobile
+    from app.views import auth
+    from app.views import dashboard
+    from app.views import home
+    from app.views import patients
+    from app.views import prescriptions
+
+    app.register_blueprint(mobile.bp)
+    app.register_blueprint(auth.bp)
+    app.register_blueprint(dashboard.bp)
+    app.register_blueprint(home.bp)
+    app.register_blueprint(patients.bp)
+    app.register_blueprint(prescriptions.bp)
+
+    return app

--- a/app/models/medication.py
+++ b/app/models/medication.py
@@ -187,7 +187,3 @@ class Intake(db.Model):
     prescription_id = db.Column(
         db.Integer, db.ForeignKey("prescription.id"), nullable=False
     )
-
-
-db.create_all()
-db.session.commit()


### PR DESCRIPTION
This PR changes how instances of our Flask application are created. Rather than create a Flask instance globally and then configure it, we now return a configured Flask instance in the `create_app()` function. This follows the recent ["application factory"](https://flask.palletsprojects.com/en/1.1.x/tutorial/factory/#the-application-factory) paradigm.

This is a first step towards #153, as the application factory paradigm lets us set up and teardown a fresh `db` on each test run.