### PR TITLE
add youtube to splash.html, logo redirect to splash.html

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -56,7 +56,7 @@
     <ul class="navbar-nav sidebar sidebar-dark accordion" id="accordionSidebar" style="background-color:#007BFF;">
 
       <!-- Sidebar - Brand -->
-      <a class="sidebar-brand d-flex align-items-center justify-content-center" href="/dashboard">
+      <a class="sidebar-brand d-flex align-items-center justify-content-center" href="/home">
         <div class="sidebar-brand-icon rotate-n-15">
           <i class="fas fa-prescription-bottle-alt fa-2x"></i>
         </div>

--- a/app/templates/home/splash.html
+++ b/app/templates/home/splash.html
@@ -32,13 +32,12 @@
 
   <!-- Custom styles for this template -->
   <link href="{{ url_for('static', filename='css/landing-page.min.css') }}" rel="stylesheet">
-
 </head>
 
 <body>
   <!-- Masthead -->
   <header class="masthead text-white text-center">
-    <div class="overlay"></div>
+  <div class="overlay"></div>
     <div class="container">
       <div class="row">
         <div class="col-xl-9 mx-auto">
@@ -47,7 +46,7 @@
         </div>
         <div class="col-md-10 col-lg-8 col-xl-7 mx-auto">
           <form>
-            <div class="form-row" style="width: 60%; margin: auto;">
+            <div class="form-row mb-5" style="width: 60%; margin: auto;">
               <div class="col-12 col-md-6 mb-2 mb-md-0">
                 <a class="btn btn-block btn-lg btn-primary" href="/about" role="button"
                    target="_blank"
@@ -61,9 +60,14 @@
             </div>
           </form>
         </div>
+        <div class="container-fluid col-md-10 col-lg-8 col-xl-7 mx-auto mt-4">
+          <iframe width="640" height="360" src="https://www.youtube.com/embed/3HuoyBIA94o"
+                  frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+        </div>
       </div>
     </div>
   </header>
+
 
   <!-- Icons Grid -->
   <section class="features-icons bg-light text-center">


### PR DESCRIPTION
Fixes #151 
• Add youtube video to splash.html
• Fix the logo to redirect to splash.html

<img width="1680" alt="Screen Shot 2020-05-26 at 1 33 27 AM" src="https://user-images.githubusercontent.com/6101844/82879920-7fb40580-9ef2-11ea-9c72-5327dc083f2e.png">
