### PR TITLE
Postgres setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 **
 !app
 !modeling
-!config.py
 !requirements.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Ignore secrets
+.env
+
 # Ignore project data
 data/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:18.04
 
-ENV LC_ALL=C.UTF-8 \
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    LC_ALL=C.UTF-8 \
     LANG=C.UTF-8
 
 RUN apt-get update && \
@@ -14,7 +15,3 @@ COPY requirements.txt /app/requirements.txt
 RUN python3.7 -m pip install --no-cache-dir -r requirements.txt
 
 COPY . /app
-
-EXPOSE 5000
-
-ENTRYPOINT ["flask", "run", "--host=0.0.0.0"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,3 +15,5 @@ COPY requirements.txt /app/requirements.txt
 RUN python3.7 -m pip install --no-cache-dir -r requirements.txt
 
 COPY . /app
+
+CMD flask run --host=0.0.0.0 --port=5000

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -12,13 +12,13 @@ db = SQLAlchemy()
 login_manager = LoginManager()
 
 
-def create_app(testing=False):
+def create_app(test=False):
     """Create and configure an instance of the Flask app."""
     app = Flask(__name__)
     app.secret_key = os.urandom(33)  # For CSRF token
     app.config.from_object("app.config.Config")
 
-    if testing:
+    if test:
         app.config.from_object("app.config.TestConfig")
 
     login_manager.init_app(app)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -12,11 +12,14 @@ db = SQLAlchemy()
 login_manager = LoginManager()
 
 
-def create_app():
+def create_app(testing=False):
     """Create and configure an instance of the Flask app."""
     app = Flask(__name__)
     app.secret_key = os.urandom(33)  # For CSRF token
     app.config.from_object("app.config.Config")
+
+    if testing:
+        app.config.from_object("app.config.TestConfig")
 
     login_manager.init_app(app)
     db.init_app(app)

--- a/app/config.py
+++ b/app/config.py
@@ -8,7 +8,7 @@ class Config(object):
     """Base class for Flask configuration."""
 
     SECRET_KEY = os.urandom(33)
-    SQLALCHEMY_DATABASE_URI = os.environ["POSTGRES_URL"]
+    SQLALCHEMY_DATABASE_URI = os.getenv("POSTGRES_URL")
     SQLALCHEMY_TRACK_MODIFICATIONS = False
 
 

--- a/app/config.py
+++ b/app/config.py
@@ -8,7 +8,7 @@ class Config(object):
     """Base class for Flask configuration."""
 
     SECRET_KEY = os.urandom(33)
-    SQLALCHEMY_DATABASE_URI = "sqlite:///" + os.path.join(basedir, "sparkle.db")
+    SQLALCHEMY_DATABASE_URI = os.environ["POSTGRES_URL"]
     SQLALCHEMY_TRACK_MODIFICATIONS = False
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,11 +2,9 @@ version: "3"
 services:
   web:
     build: .
-    command: python3.7 -m flask run --host=0.0.0.0 --port=5000
-    environment:
-      - FLASK_APP=app
-      - FLASK_ENV
-      - POSTGRES_URL
+    command: python3.7 -m flask run --host=0.0.0.0
+    env_file:
+      - .env
     volumes:
       - .:/app
     ports:
@@ -16,9 +14,7 @@ services:
 
   db:
     image: postgres
-    environment:
-      - POSTGRES_DB
-      - POSTGRES_USER
-      - POSTGRES_PASSWORD
+    env_file:
+      - .env
     volumes:
       - ./data/database:/var/lib/postgresql/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,11 +2,23 @@ version: "3"
 services:
   web:
     build: .
-    command: flask run --host=0.0.0.0 --port=5000
+    command: python3.7 -m flask run --host=0.0.0.0 --port=5000
     environment:
       - FLASK_APP=app
       - FLASK_ENV
+      - POSTGRES_URL
     volumes:
       - .:/app
     ports:
       - "5000:5000"
+    depends_on:
+      - db
+
+  db:
+    image: postgres
+    environment:
+      - POSTGRES_DB
+      - POSTGRES_USER
+      - POSTGRES_PASSWORD
+    volumes:
+      - ./data/database:/var/lib/postgresql/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,9 @@ version: "3"
 services:
   web:
     build: .
+    command: flask run --host=0.0.0.0 --port=5000
     environment:
       - FLASK_APP=app
-      - FLASK_RUN_PORT=5000
       - FLASK_ENV
     volumes:
       - .:/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,6 @@ version: "3"
 services:
   web:
     build: .
-    command: python3.7 -m flask run --host=0.0.0.0
     env_file:
       - .env
     volumes:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ numpy==1.18.2
 pandas==1.0.3
 pickleshare==0.7.5
 plotly==4.6.0
-psycopg2-binary==2.8.5
 pytest==5.4.1
 requests==2.23.0
 scikit-learn==0.22.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ pandas==1.0.3
 pickleshare==0.7.5
 plotly==4.6.0
 psycopg2-binary==2.8.5
+pytest==5.4.1
 requests==2.23.0
 scikit-learn==0.22.1
 xgboost==0.90

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ numpy==1.18.2
 pandas==1.0.3
 pickleshare==0.7.5
 plotly==4.6.0
+psycopg2-binary==2.8.5
 pytest==5.4.1
 requests==2.23.0
 scikit-learn==0.22.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,8 +17,7 @@ from app.models.persons import User
 @pytest.fixture
 def app():
     """Configure a new Flask app instance and db for each test."""
-    app = create_app()
-    app.config.from_object("app.config.TestConfig")
+    app = create_app(testing=True)
     with app.app_context():
         db.create_all()
         yield app

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ from app.models.persons import User
 @pytest.fixture
 def app():
     """Configure a new Flask app instance and db for each test."""
-    app = create_app(testing=True)
+    app = create_app(test=True)
     with app.app_context():
         db.create_all()
         yield app


### PR DESCRIPTION
Fixes #164. 

This PR modifies our docker flow to run `postgres` in a separate container. Our app is able to talk to the database by pointing `sql-alchemy` to the right `POSTGRES_URL`.

To launch the app locally, you can still run `docker-compose up`, which will launch both containers for the app and db. One minor issue is that, although we can guarantee that the db container starts first (by telling `web` to `depend_on: db`), this doesn't guarantee that the db container is ready to accept incoming requests. This sometimes results in errors initially, which go away after the db has finished setting itself up inside the container. 