### PR TITLE
Postgres docker setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 **
 !app
 !modeling
-!config.py
 !requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:18.04
 
-ENV LC_ALL=C.UTF-8 \
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    LC_ALL=C.UTF-8 \
     LANG=C.UTF-8
 
 RUN apt-get update && \
@@ -15,6 +16,6 @@ RUN python3.7 -m pip install --no-cache-dir -r requirements.txt
 
 COPY . /app
 
-EXPOSE 5000
+EXPOSE 8080
 
-ENTRYPOINT ["flask", "run", "--host=0.0.0.0"]
+CMD gunicorn --preload --worker-tmp-dir /dev/shm -w 3 --threads 4 -k gthread -b 0.0.0.0:8080 "app:create_app()"

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ COPY . /app
 
 EXPOSE 8080
 
-CMD gunicorn --preload --worker-tmp-dir /dev/shm -w 3 --threads 4 -k gthread -b 0.0.0.0:8080 "app:create_app()"
+CMD gunicorn --preload --worker-tmp-dir /dev/shm -w 3 -b 0.0.0.0:8080 "app:create_app()"

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ COPY . /app
 
 EXPOSE 8080
 
-CMD gunicorn --preload --worker-tmp-dir /dev/shm -w 3 -b 0.0.0.0:8080 "app:create_app()"
+CMD gunicorn --preload --worker-tmp-dir /dev/shm -w 2 --threads 3 -k gthread -b 0.0.0.0:8080 "app:create_app()"

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -40,5 +40,6 @@ def create_app(test=False):
 
     with app.app_context():
         db.create_all()
+        db.engine.dispose()
 
     return app

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -12,11 +12,14 @@ db = SQLAlchemy()
 login_manager = LoginManager()
 
 
-def create_app():
+def create_app(test=False):
     """Create and configure an instance of the Flask app."""
     app = Flask(__name__)
     app.secret_key = os.urandom(33)  # For CSRF token
     app.config.from_object("app.config.Config")
+
+    if test:
+        app.config.from_object("app.config.TestConfig")
 
     login_manager.init_app(app)
     db.init_app(app)

--- a/app/config.py
+++ b/app/config.py
@@ -1,9 +1,6 @@
 import os
 
 
-basedir = os.path.abspath(os.path.dirname(__file__))
-
-
 class Config(object):
     """Base class for Flask configuration."""
 

--- a/app/config.py
+++ b/app/config.py
@@ -8,7 +8,7 @@ class Config(object):
     """Base class for Flask configuration."""
 
     SECRET_KEY = os.urandom(33)
-    SQLALCHEMY_DATABASE_URI = "sqlite:///" + os.path.join(basedir, "sparkle.db")
+    SQLALCHEMY_DATABASE_URI = os.getenv("POSTGRES_URL")
     SQLALCHEMY_TRACK_MODIFICATIONS = False
 
 

--- a/app/models/medication.py
+++ b/app/models/medication.py
@@ -44,7 +44,7 @@ class Prescription(db.Model):
     strength = db.Column(db.Integer, unique=False, nullable=False)
     strength_unit = db.Column(db.String(20), unique=False, nullable=False)
     quantity = db.Column(db.Integer, unique=False, nullable=False)
-    drug_form = db.Column(db.String(20), unique=False, nullable=False)
+    form = db.Column(db.String(20), unique=False, nullable=False)
     amount = db.Column(db.Integer, unique=False, nullable=False)
     route = db.Column(db.String(10), unique=False, nullable=False)
     freq = db.Column(db.Integer, unique=False, nullable=False)

--- a/app/templates/prescriptions/add_prescription.html
+++ b/app/templates/prescriptions/add_prescription.html
@@ -60,8 +60,8 @@
 				    		<input id="quantity" class="form-control" name="quantity" placeholder="10" required>
 						</div>
 						<div class="form-group col-md-1">
-				    		<label for="drug_form">&nbsp;</label>
-				    		<select class="form-control" id="drug_form" name="drug_form" required>
+				    		<label for="form">&nbsp;</label>
+				    		<select class="form-control" id="form" name="form" required>
 						      <option>Tab</option>
 						      <option>Chew Tab</option>
 						      <option>Cap</option>

--- a/app/views/prescriptions.py
+++ b/app/views/prescriptions.py
@@ -83,16 +83,12 @@ def add_prescription(patient_id):
         )
         rx_fields["days_until_refill"] = days_until_refill
 
-        for k, v in rx_fields.items():
-            print(f"{k}: {v}")
-
         # Create Rx
         rx = Prescription(**rx_fields)
         db.session.add(rx)
         db.session.commit()
 
         return redirect(url_for("patients.profile", patient_id=patient_id))
-    print(rx_form.errors)
     return render_template(
         "prescriptions/add_prescription.html", patient=patient, form=rx_form
     )

--- a/app/views/prescriptions.py
+++ b/app/views/prescriptions.py
@@ -34,7 +34,7 @@ def add_prescription(patient_id):
             "strength": int(f.get("strength")),
             "strength_unit": f.get("strength_unit"),
             "quantity": int(f.get("quantity")),
-            "drug_form": f.get("drug_form"),
+            "form": f.get("form"),
             "amount": int(f.get("amount")),
             "route": f.get("route"),
             "duration": int(f.get("duration")),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,11 +2,20 @@ version: "3"
 services:
   web:
     build: .
+    restart: always
     environment:
-      - FLASK_APP=app
-      - FLASK_RUN_PORT=5000
       - FLASK_ENV
+      - POSTGRES_URL
     volumes:
       - .:/app
     ports:
-      - "5000:5000"
+      - "8080:8080"
+    depends_on:
+      - db
+
+  db:
+    image: postgres
+    environment:
+      - POSTGRES_PASSWORD
+    volumes:
+      - ./data/database:/var/lib/postgresql/data

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ Flask==1.1.2
 Flask-Login==0.5.0
 Flask-SQLAlchemy==2.4.1
 Flask-WTF==0.14.3
+gunicorn==20.0.4
 numpy==1.18.2
 pandas==1.0.3
 pickleshare==0.7.5

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,8 +17,7 @@ from app.models.persons import User
 @pytest.fixture
 def app():
     """Configure a new Flask app instance and db for each test."""
-    app = create_app()
-    app.config.from_object("app.config.TestConfig")
+    app = create_app(test=True)
     with app.app_context():
         db.create_all()
         yield app

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -145,7 +145,7 @@ def rx_data():
         "strength": 30,
         "strength_unit": "mg",
         "quantity": 30,
-        "drug_form": "tab",
+        "form": "tab",
         "amount": 1,
         "route": "oral",
         "freq": 1,


### PR DESCRIPTION
Fixes #187 and fixes #164 . 

1. This main purpose of this PR is to set up running postgres in a second docker container. Now `docker-compose up` launches our app in one container and a postgres db in another. There are two environment variables that need to be set for Docker:

* `POSTGRES_PASSWORD` -- A password for the default `postgres` user
* `POSTGRES_URL` -- the `postgres` connection string, which depends on the password

For example, if you set `POSTGRES_PASSWORD=sparkle`, the connection string would be

```
POSTGRES_URL=postgresql+psycopg2://postgres:sparkle@db:5432
```

2. The second purpose of this PR is to configure `gunicorn` as the production server for our app. We set `--workers=2` and `--threads=3` as reasonable defaults for a `t2.small` instance (which has 2 cores). We might need to tune these to optimize performance on each `ec2` instance. 

One thing we needed to do in order to enable using multiple workers is add `db.engine.dispose()` inside `app/__init__.py` right after creating the tables. The reason is that `psycopg2`, while being thread safe, does not support forking processes. Each forked gunicorn process shares the database connection of its parent process, which is a no-no for `psycopg2`. The solution (I think) is to force the processes to create new connections to the database by disposing of the initial db connection. [This post](https://virtualandy.wordpress.com/tag/python/) gave us the answer.