### PR TITLE
Fix deploy.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: deploy
+name: build
 on:
   push:
     branches:
@@ -22,6 +22,7 @@ jobs:
         aws_secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         application_name: Sparkle
         environment_name: sparkle
+        version_label: ${{ github.SHA }}
         region: us-west-2
         deployment_package: deploy.zip
         wait_for_environment_recovery: "60"


### PR DESCRIPTION
Builds upon #189. Adds the required `version_label` parameter in the workflow and sets it to the `GITHUB_SHA` of the deployed commit. 