### PR TITLE
tag deploys with SHA, label with REF

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,8 +22,8 @@ jobs:
         aws_secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         application_name: Sparkle
         environment_name: sparkle
-        version_label: ${{ github.REF }}
-        version_description: ${{ github.SHA }}
+        version_label: ${{ github.SHA }}
+        version_description: ${{ github.REF }}
         region: us-west-2
         deployment_package: deploy.zip
         wait_for_environment_recovery: "60"


### PR DESCRIPTION
Fixes bug in `build.yml`: `version_label` did not accept `github.REF` as valid input. We set the label to `github.SHA` and the description to `github.REF` as a workaround.