### PR TITLE
Deploy existing package version if available

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
         application_name: Sparkle
         environment_name: sparkle
         version_label: ${{ github.SHA }}
-        version_description: ${{ github.REF }}
         region: us-west-2
         deployment_package: deploy.zip
+        use_existing_version_if_available: true
         wait_for_environment_recovery: "60"


### PR DESCRIPTION
This PR enables re-running our `build` workflow manually in case of failure by setting `use_existing_version_if_available = true`. We're also removing the `version_description` as it will always say `refs/head/master` since we only build on merges to master.