### PR TITLE
Show video below tagline on homepage

### DIFF
--- a/app/templates/home/splash.html
+++ b/app/templates/home/splash.html
@@ -44,9 +44,14 @@
           <h1>Lift off to better health outcomes.</h1>
           <h2 class="mb-5">Mission control for medication adherence</h2>
         </div>
+        <div class="embed-responsive embed-responsive-16by9 col-xl-7 col-centered mx-auto">
+          <iframe class = "embed-responsive" src="https://www.youtube-nocookie.com/embed/3HuoyBIA94o?vq=hd1080&rel=0"
+                  frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen>
+          </iframe>
+        </div>
         <div class="col-md-10 col-lg-8 col-xl-7 mx-auto">
           <form>
-            <div class="form-row mb-5" style="width: 60%; margin: auto;">
+            <div class="form-row mb-5" style="padding-top: 1.2cm; width: 60%; margin: auto;">
               <div class="col-12 col-md-6 mb-2 mb-md-0">
                 <a class="btn btn-block btn-lg btn-primary" href="/about" role="button"
                    target="_blank"
@@ -59,10 +64,6 @@
               </div>
             </div>
           </form>
-        </div>
-        <div class="embed-responsive embed-responsive-16by9 col-xl-7 col-centered mx-auto">
-          <iframe class = "embed-responsive" src="https://www.youtube.com/embed/3HuoyBIA94o"
-                  frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
         </div>
       </div>
     </div>
@@ -171,7 +172,7 @@
         </div>
         <div class="col-md-10 col-lg-8 col-xl-7 mx-auto">
         	<a class="btn btn-block btn-lg btn-primary"
-        	   style="width: 20%; margin: auto;"
+        	   style="max-width: 30%; margin: auto;"
         	   href="/register" role="button">Sign up</a>
         </div>
       </div>


### PR DESCRIPTION
Tweaks the layout of the homepage to show the video right below the tagline.

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/48395294/84972197-3c088200-b0d3-11ea-811a-82689a755c41.png">
